### PR TITLE
Add cheerful BotGuys marketing site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BotGuys | Bot Defense Testing & Optimization</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="hero" id="top">
+        <div class="nav">
+            <div class="logo">BotGuys</div>
+            <nav>
+                <a href="#services">Services</a>
+                <a href="#report">Sample Report</a>
+                <a href="#industries">Industries</a>
+                <a href="#approach">Approach</a>
+                <a href="#contact">Contact</a>
+            </nav>
+        </div>
+        <div class="hero-content">
+            <div class="hero-text">
+                <h1>Friendly Experts in Beating Bad Bots</h1>
+                <p>
+                    BotGuys helps you test, tune, and transform your bot defenses with a smile. From automated attacks
+                    to stealthy scrapers, we stress test your protection stack and deliver actionable improvements.
+                </p>
+                <a class="cta" href="#contact">Contact for a Quote</a>
+            </div>
+            <div class="hero-card">
+                <h2>Quick Snapshot</h2>
+                <ul>
+                    <li>Hands-on bot pentesting</li>
+                    <li>Fine-tuning &amp; optimization support</li>
+                    <li>Coverage across web, mobile, and APIs</li>
+                    <li>Friendly experts ready to collaborate</li>
+                </ul>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section" id="services">
+            <div class="section-heading">
+                <span class="eyebrow">What We Do</span>
+                <h2>Bot Defense Testing, Optimization &amp; Enhancement</h2>
+                <p>
+                    We evaluate and uplift the entire lifecycle of your bot defense strategy. Whether you need a fresh
+                    evaluation, a deeper audit, or help integrating additional safeguards, BotGuys is your cheerful bot
+                    protection partner.
+                </p>
+            </div>
+            <div class="card-grid">
+                <article class="card">
+                    <h3>Red-Team Style Bot Testing</h3>
+                    <p>
+                        Simulate the latest automation tactics including multi-stage bots, rotating identities, and
+                        human-in-the-loop augmentation to measure true resilience.
+                    </p>
+                </article>
+                <article class="card">
+                    <h3>Defense Optimization</h3>
+                    <p>
+                        Tune rate limits, behavioral analytics, and risk scoring rules to cut false positives while
+                        keeping fraudsters out. We partner with your team to deploy improvements fast.
+                    </p>
+                </article>
+                <article class="card">
+                    <h3>Solution Augmentation</h3>
+                    <p>
+                        Evaluate new vendors, deploy additional sensors, or build custom mitigations. We help you boost
+                        your stack without the guesswork.
+                    </p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section alt" id="report">
+            <div class="section-heading">
+                <span class="eyebrow">Sample Findings</span>
+                <h2>What a BotGuys Report Looks Like</h2>
+                <p>
+                    Every engagement includes a colorful, plain-language report summarizing detection bypasses,
+                    mitigation gaps, and prioritized recommendations. Here’s a sample snapshot of the checks we run.
+                </p>
+            </div>
+            <div class="report">
+                <div class="report-card">
+                    <h3>Automation Signals</h3>
+                    <ul>
+                        <li><strong>Selenium &amp; WebDriver:</strong> Detected session tokens bypassed via driver spoofing.</li>
+                        <li><strong>Chrome Headless:</strong> Mitigation evaded by customizing navigator properties.</li>
+                        <li><strong>Playwright Scripts:</strong> Behavioral patterns blend into human baselines.</li>
+                    </ul>
+                </div>
+                <div class="report-card">
+                    <h3>Identity Obfuscation</h3>
+                    <ul>
+                        <li><strong>Residential Proxy Detection:</strong> Flagging delayed by slow ASN updates.</li>
+                        <li><strong>Mobile Device Farms:</strong> Risk scoring reduced through device ID cycling.</li>
+                        <li><strong>VPN Blending:</strong> Mitigation bypassed via custom TLS ciphers.</li>
+                    </ul>
+                </div>
+                <div class="report-card">
+                    <h3>Signal Integrity</h3>
+                    <ul>
+                        <li><strong>TLS Fingerprinting:</strong> JA3 anomalies suppressed with library patching.</li>
+                        <li><strong>Canvas &amp; WebGL:</strong> Hash checks neutralized via pixel noise insertion.</li>
+                        <li><strong>Audio/Video Captures:</strong> Bypass achieved through synthetic media generation.</li>
+                    </ul>
+                </div>
+                <div class="report-card">
+                    <h3>Actionable Recommendations</h3>
+                    <ul>
+                        <li>Introduce layered sensor validation with randomized challenge logic.</li>
+                        <li>Upgrade intelligence feeds for proxy and device fingerprints.</li>
+                        <li>Deploy continuous tuning sprints with BotGuys for lasting coverage.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="industries">
+            <div class="section-heading">
+                <span class="eyebrow">Who We Help</span>
+                <h2>Vertical Expertise</h2>
+                <p>
+                    Our testers have hands-on experience safeguarding high-volume, high-value digital experiences across
+                    critical industries.
+                </p>
+            </div>
+            <div class="industries-grid">
+                <div class="industry-card">
+                    <h3>Airlines &amp; Loyalty</h3>
+                    <p>Protect seat inventories, mileage accounts, and flight search APIs from bot-induced turbulence.</p>
+                </div>
+                <div class="industry-card">
+                    <h3>Booking &amp; Ticketing</h3>
+                    <p>Block scalpers and preserve real customers’ access to events, attractions, and reservations.</p>
+                </div>
+                <div class="industry-card">
+                    <h3>Ecommerce &amp; Retail</h3>
+                    <p>Stop inventory scraping, account takeovers, and checkout automation while keeping shoppers happy.</p>
+                </div>
+                <div class="industry-card">
+                    <h3>Government &amp; Healthcare</h3>
+                    <p>Shield citizen portals, benefits systems, and scheduling tools from bots and fraudsters.</p>
+                </div>
+                <div class="industry-card">
+                    <h3>AI Data Mining Scrapers</h3>
+                    <p>Safeguard proprietary datasets and premium content from unauthorized harvesting.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section alt" id="approach">
+            <div class="section-heading">
+                <span class="eyebrow">How We Work</span>
+                <h2>Cheerful Collaboration, Serious Results</h2>
+                <p>
+                    We blend friendly teamwork with rigorous methodology. Expect quick communication, transparent
+                    findings, and experts who love what they do.
+                </p>
+            </div>
+            <div class="timeline">
+                <div class="timeline-item">
+                    <div class="timeline-icon">1</div>
+                    <div class="timeline-content">
+                        <h3>Discovery Workshop</h3>
+                        <p>Understand your architecture, current controls, and key risk indicators.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-icon">2</div>
+                    <div class="timeline-content">
+                        <h3>Emulated Bot Campaigns</h3>
+                        <p>Run crafted attack scenarios against web, mobile, and API surfaces.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-icon">3</div>
+                    <div class="timeline-content">
+                        <h3>Fine-Tuning Sprints</h3>
+                        <p>Collaborate to iterate on mitigations, configurations, and analytics pipelines.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-icon">4</div>
+                    <div class="timeline-content">
+                        <h3>Ongoing Partnership</h3>
+                        <p>Schedule quarterly health checks or managed threat simulations to stay ahead.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section contact" id="contact">
+            <div class="contact-card">
+                <div class="contact-intro">
+                    <span class="eyebrow">Let’s Chat</span>
+                    <h2>Contact BotGuys for a Quote</h2>
+                    <p>
+                        Ready to strengthen your bot defenses? Tell us about your environment and goals, and we’ll craft a
+                        custom engagement plan.
+                    </p>
+                    <div class="contact-highlights">
+                        <div>
+                            <h3>What You Get</h3>
+                            <ul>
+                                <li>Tailored testing strategy</li>
+                                <li>Actionable improvement roadmap</li>
+                                <li>Friendly experts on call</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h3>Response Time</h3>
+                            <p>We typically respond within one business day.</p>
+                        </div>
+                    </div>
+                </div>
+                <form class="contact-form">
+                    <label for="name">Name</label>
+                    <input type="text" id="name" name="name" placeholder="Jane Doe" required>
+
+                    <label for="email">Work Email</label>
+                    <input type="email" id="email" name="email" placeholder="you@company.com" required>
+
+                    <label for="company">Company</label>
+                    <input type="text" id="company" name="company" placeholder="BotGuys" required>
+
+                    <label for="industry">Industry</label>
+                    <select id="industry" name="industry">
+                        <option value="">Select an industry</option>
+                        <option value="airlines">Airlines</option>
+                        <option value="booking">Booking &amp; Ticketing</option>
+                        <option value="ecommerce">Ecommerce</option>
+                        <option value="government">Government &amp; Healthcare</option>
+                        <option value="ai">AI Data Protection</option>
+                        <option value="other">Other</option>
+                    </select>
+
+                    <label for="message">Tell us about your needs</label>
+                    <textarea id="message" name="message" rows="4" placeholder="Share your goals, challenges, and timeline"></textarea>
+
+                    <button type="submit">Contact for Quote</button>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <div>
+                <div class="logo">BotGuys</div>
+                <p>Bot defense testers &amp; optimizers with a friendly touch.</p>
+            </div>
+            <div class="footer-links">
+                <a href="#services">Services</a>
+                <a href="#report">Sample Report</a>
+                <a href="#industries">Industries</a>
+                <a href="#approach">Approach</a>
+                <a href="#contact">Contact</a>
+            </div>
+        </div>
+        <p class="footer-note">&copy; <span id="year"></span> BotGuys. All rights reserved.</p>
+    </footer>
+
+    <script>
+        const yearEl = document.getElementById('year');
+        if (yearEl) {
+            yearEl.textContent = new Date().getFullYear();
+        }
+    </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,401 @@
+:root {
+    --bg: #f7f8ff;
+    --bg-alt: #ffffff;
+    --accent: #6c5ce7;
+    --accent-soft: rgba(108, 92, 231, 0.1);
+    --accent-strong: #4834d4;
+    --text: #2d3436;
+    --muted: #636e72;
+    --highlight: #00cec9;
+    font-size: 16px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+h1, h2, h3, h4 {
+    margin-top: 0;
+    color: var(--text);
+}
+
+p {
+    margin-top: 0;
+    color: var(--muted);
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+a:hover,
+.nav a:focus {
+    text-decoration: underline;
+}
+
+.hero {
+    background: linear-gradient(135deg, rgba(108, 92, 231, 0.15), rgba(0, 206, 201, 0.1));
+    padding: 2.5rem 5vw 4rem;
+}
+
+.nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.logo {
+    font-weight: 700;
+    font-size: 1.5rem;
+    color: var(--accent-strong);
+}
+
+.nav nav {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.nav a {
+    font-weight: 500;
+    padding: 0.5rem 0.75rem;
+    border-radius: 999px;
+    transition: background 0.3s ease;
+}
+
+.nav a:hover {
+    background: var(--accent-soft);
+}
+
+.hero-content {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: center;
+    margin-top: 2.5rem;
+}
+
+.hero-text h1 {
+    font-size: clamp(2.2rem, 4vw, 3rem);
+}
+
+.hero-text p {
+    font-size: 1.05rem;
+    max-width: 560px;
+}
+
+.cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.75rem;
+    margin-top: 1.5rem;
+    background: var(--accent);
+    color: white;
+    border-radius: 999px;
+    font-weight: 600;
+    box-shadow: 0 10px 20px rgba(108, 92, 231, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(108, 92, 231, 0.3);
+}
+
+.hero-card {
+    background: var(--bg-alt);
+    border-radius: 16px;
+    padding: 1.75rem;
+    box-shadow: 0 10px 30px rgba(76, 81, 191, 0.12);
+}
+
+.hero-card h2 {
+    margin-bottom: 1rem;
+    font-size: 1.4rem;
+}
+
+.hero-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.hero-card li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.hero-card li::before {
+    content: '😊';
+}
+
+.section {
+    padding: 4.5rem 5vw;
+}
+
+.section.alt {
+    background: var(--bg-alt);
+}
+
+.section-heading {
+    max-width: 720px;
+    margin: 0 auto 3rem;
+    text-align: center;
+}
+
+.eyebrow {
+    display: inline-block;
+    background: var(--accent-soft);
+    color: var(--accent-strong);
+    font-weight: 600;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.card-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+    background: var(--bg-alt);
+    border-radius: 16px;
+    padding: 1.75rem;
+    box-shadow: 0 12px 28px rgba(45, 52, 54, 0.1);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 36px rgba(45, 52, 54, 0.18);
+}
+
+.report {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.report-card {
+    background: linear-gradient(160deg, rgba(108, 92, 231, 0.12), rgba(0, 206, 201, 0.12));
+    border-radius: 18px;
+    padding: 1.75rem;
+    backdrop-filter: blur(8px);
+}
+
+.report-card h3 {
+    margin-bottom: 1rem;
+}
+
+.report-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.report-card li + li {
+    margin-top: 0.65rem;
+}
+
+.report-card strong {
+    color: var(--text);
+}
+
+.industries-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.industry-card {
+    background: var(--bg-alt);
+    border-left: 4px solid var(--highlight);
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+    transition: transform 0.3s ease;
+}
+
+.industry-card:hover {
+    transform: translateY(-3px);
+}
+
+.timeline {
+    position: relative;
+    display: grid;
+    gap: 1.75rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: calc(1.25rem - 1px);
+    width: 2px;
+    height: 100%;
+    background: linear-gradient(180deg, rgba(108, 92, 231, 0.5), rgba(0, 206, 201, 0.5));
+}
+
+.timeline-item {
+    display: flex;
+    gap: 1.5rem;
+    align-items: flex-start;
+}
+
+.timeline-icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    background: var(--accent);
+    color: white;
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+    box-shadow: 0 10px 20px rgba(108, 92, 231, 0.3);
+    flex-shrink: 0;
+}
+
+.timeline-content {
+    background: var(--bg-alt);
+    border-radius: 16px;
+    padding: 1.25rem 1.5rem;
+    box-shadow: 0 10px 24px rgba(108, 92, 231, 0.12);
+}
+
+.contact {
+    background: linear-gradient(135deg, rgba(108, 92, 231, 0.1), rgba(0, 206, 201, 0.15));
+}
+
+.contact-card {
+    background: var(--bg-alt);
+    border-radius: 24px;
+    padding: 2.5rem;
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    box-shadow: 0 20px 48px rgba(76, 81, 191, 0.18);
+}
+
+.contact-intro ul {
+    padding-left: 1.1rem;
+}
+
+.contact-form {
+    display: grid;
+    gap: 1rem;
+}
+
+.contact-form label {
+    font-weight: 600;
+}
+
+.contact-form input,
+.contact-form select,
+.contact-form textarea {
+    width: 100%;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid rgba(99, 110, 114, 0.2);
+    border-radius: 10px;
+    font: inherit;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-form input:focus,
+.contact-form select:focus,
+.contact-form textarea:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(108, 92, 231, 0.15);
+    outline: none;
+}
+
+.contact-form button {
+    margin-top: 0.5rem;
+    padding: 0.9rem 1.5rem;
+    border: none;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--accent), var(--highlight));
+    color: white;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 12px 28px rgba(108, 92, 231, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-form button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(108, 92, 231, 0.3);
+}
+
+.footer {
+    padding: 2.5rem 5vw;
+    background: #f0f1ff;
+}
+
+.footer-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    align-items: flex-start;
+}
+
+.footer-links {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.footer-note {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+@media (min-width: 820px) {
+    .footer-content {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+    }
+}
+
+@media (max-width: 600px) {
+    .hero {
+        padding: 2rem 6vw 3rem;
+    }
+
+    .section {
+        padding: 3.5rem 6vw;
+    }
+
+    .timeline::before {
+        left: calc(1rem - 1px);
+    }
+
+    .timeline-icon {
+        width: 2.25rem;
+        height: 2.25rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add a static marketing landing page highlighting BotGuys bot-defense testing and optimization services
- showcase a sample engagement report, vertical expertise, and collaborative approach
- include a friendly contact form encouraging visitors to request a quote

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d49cbab0f08326b73daf87363b27db